### PR TITLE
SMB 3.1.1 min support + fix compile error in jar path

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -5,9 +5,9 @@
 	<classpathentry kind="lib" path="jars/bcprov-jdk15on-158.jar"/>
 	<classpathentry kind="lib" path="jars/javax.servlet.jar"/>
 	<classpathentry kind="lib" path="jars/jcifs-1.3.17_patch.jar"/>
-	<classpathentry kind="lib" path="D:/PGMS/JcifsFile/jars/jcifs-ng-2.1.0-mod-08.jar"/>
+	<classpathentry kind="lib" path="jars/jcifs-ng-2.1.0-mod-08.jar"/>
 	<classpathentry kind="lib" path="jars/WrapperForSlf4j-1.0.2.jar"/>
-	<classpathentry kind="lib" path="D:/PGMS/JcifsFile/jars/jcifs-ng-2.1.1-20190202-03.jar"/>
+	<classpathentry kind="lib" path="jars/jcifs-ng-2.1.1-20190202-03.jar"/>
 	<classpathentry kind="lib" path="jars/jcifs-ng-2.1.2-20190324-01.jar"/>
 	<classpathentry kind="lib" path="jars/jcifs-ng-2.1.4-20200413-01.jar"/>
 	<classpathentry kind="output" path="bin"/>

--- a/src/com/sentaroh/jcifs/JcifsAuth.java
+++ b/src/com/sentaroh/jcifs/JcifsAuth.java
@@ -83,7 +83,7 @@ public class JcifsAuth {
             try {
                 Properties prop = new Properties();
                 prop.setProperty("jcifs.smb.client.minVersion", "SMB202");
-                prop.setProperty("jcifs.smb.client.maxVersion", "SMB300");
+                prop.setProperty("jcifs.smb.client.maxVersion", "SMB311");
                 jcifsng212.context.BaseContext bc = new jcifsng212.context.BaseContext(new jcifsng212.config.PropertyConfiguration(prop));
                 jcifsng212.smb.NtlmPasswordAuthentication creds = new jcifsng212.smb.NtlmPasswordAuthentication(bc, domain, user, pass);
                 mSmb212Auth = bc.withCredentials(creds);
@@ -94,7 +94,7 @@ public class JcifsAuth {
             try {
                 Properties prop = new Properties();
                 prop.setProperty("jcifs.smb.client.minVersion", "SMB202");
-                prop.setProperty("jcifs.smb.client.maxVersion", "SMB300");
+                prop.setProperty("jcifs.smb.client.maxVersion", "SMB311");
                 jcifsng214.context.BaseContext bc = new jcifsng214.context.BaseContext(new jcifsng214.config.PropertyConfiguration(prop));
                 jcifsng214.smb.NtlmPasswordAuthentication creds = new jcifsng214.smb.NtlmPasswordAuthentication(bc, domain, user, pass);
                 mSmb214Auth = bc.withCredentials(creds);
@@ -155,7 +155,7 @@ public class JcifsAuth {
                 else prop.setProperty("jcifs.smb.client.ipcSigningEnforced", "false");
                 
                 prop.setProperty("jcifs.smb.client.minVersion", "SMB202");
-                prop.setProperty("jcifs.smb.client.maxVersion", "SMB300");
+                prop.setProperty("jcifs.smb.client.maxVersion", "SMB311");
 
                 jcifsng212.context.BaseContext bc = new jcifsng212.context.BaseContext(new jcifsng212.config.PropertyConfiguration(prop));
                 jcifsng212.smb.NtlmPasswordAuthentication creds = new jcifsng212.smb.NtlmPasswordAuthentication(bc, domain, user, pass);
@@ -170,7 +170,7 @@ public class JcifsAuth {
                 else prop.setProperty("jcifs.smb.client.ipcSigningEnforced", "false");
 
                 prop.setProperty("jcifs.smb.client.minVersion", "SMB202");
-                prop.setProperty("jcifs.smb.client.maxVersion", "SMB300");
+                prop.setProperty("jcifs.smb.client.maxVersion", "SMB311");
                 
                 jcifsng214.context.BaseContext bc = new jcifsng214.context.BaseContext(new jcifsng214.config.PropertyConfiguration(prop));
                 jcifsng214.smb.NtlmPasswordAuthentication creds = new jcifsng214.smb.NtlmPasswordAuthentication(bc, domain, user, pass);
@@ -236,7 +236,7 @@ public class JcifsAuth {
                 else prop.setProperty("jcifs.smb.client.useSMB2Negotiation", "false");
                 
                 prop.setProperty("jcifs.smb.client.minVersion", "SMB202");
-                prop.setProperty("jcifs.smb.client.maxVersion", "SMB300");
+                prop.setProperty("jcifs.smb.client.maxVersion", "SMB311");
 
                 jcifsng212.context.BaseContext bc = new jcifsng212.context.BaseContext(new jcifsng212.config.PropertyConfiguration(prop));
                 jcifsng212.smb.NtlmPasswordAuthentication creds = new jcifsng212.smb.NtlmPasswordAuthentication(bc, domain, user, pass);
@@ -254,7 +254,7 @@ public class JcifsAuth {
                 else prop.setProperty("jcifs.smb.client.useSMB2Negotiation", "false");
                 
                 prop.setProperty("jcifs.smb.client.minVersion", "SMB202");
-                prop.setProperty("jcifs.smb.client.maxVersion", "SMB300");
+                prop.setProperty("jcifs.smb.client.maxVersion", "SMB311");
 
                 jcifsng214.context.BaseContext bc = new jcifsng214.context.BaseContext(new jcifsng214.config.PropertyConfiguration(prop));
                 jcifsng214.smb.NtlmPasswordAuthentication creds = new jcifsng214.smb.NtlmPasswordAuthentication(bc, domain, user, pass);


### PR DESCRIPTION
- JCIFS-NG 212 and 214 do support smb_max=SMB311 and will work on many 3.1.1 strict servers
- fix compile error